### PR TITLE
this way of re-enabling hlint does work for me, unlike the setf way

### DIFF
--- a/packages.el
+++ b/packages.el
@@ -42,7 +42,8 @@
     (progn
       (spacemacs|diminish intero-mode " λ" " \\")
 
-      (setf (flycheck-checker-get 'intero 'next-checkers) '((warning . haskell-hlint)))
+      (flycheck-add-next-checker 'intero
+                                 '(warning . haskell-hlint))
 
       (defun intero/insert-type ()
         (interactive)


### PR DESCRIPTION
I don't know why, but for me the version you have triggers this error:

```
Error (use-package): intero :config: Symbol’s function definition is void: \(setf\ flycheck-checker-get\)
```

The version in this PR works for me however. Using emacs 25.0.94.
