### PR TITLE
update README.org to use https to clone

### DIFF
--- a/README.org
+++ b/README.org
@@ -7,7 +7,7 @@ This layer adds [[http://commercialhaskell.github.io/intero/][Intero]] functiona
 ** Layer
 1. Clone this repository into your =private= directory
    #+BEGIN_SRC sh
-   git clone git@github.com:cydparser/spacemacs-intero.git ~/.emacs.d/private/intero
+   git clone https://github.com/cydparser/spacemacs-intero.git ~/.emacs.d/private/intero
    #+END_SRC
 2. Add =intero= to =dotspacemacs-configuration-layers=
 3. Restart Emacs


### PR DESCRIPTION
Might be simpler to use https here to avoid the following error: "The authenticity of host 'github.com (192.30.253.113)' can't be established."

related discussion: http://stackoverflow.com/questions/18710120/the-authenticity-of-host-github-com-192-30-252-128-cant-be-established
